### PR TITLE
Implement customizable output format for events

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -63,13 +63,13 @@ export default class ICSPlugin extends Plugin {
 					'time': moment(e.start).format("HH:mm"),
 					'icsName': calendarSetting.icsName,
 					'summary': e.summary,
-					'description': e.description
+					'description': e.description,
+                    'format': calendarSetting.format
 				}
 
 				if (e.location) {
 					event['location'] = e.location;
 				}
-                event['format'] = calendarSetting.format;
 				events.push(event);
 			});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,9 +91,9 @@ export default class ICSPlugin extends Plugin {
                         `- [ ] ${e.time}`,
                         e.format?.icsName ? e.icsName : null,
                         e.format?.summary ? e.summary : null,
-                        e.format?.description ? `\n\t- ${e.description}` : null,
+                        e.format?.description && e.description ? `\n\t- ${e.description}` : null,
                     ].filter(Boolean).join(' ')
-				});			
+				});
 				editor.replaceRange(mdArray.sort().join("\n"), editor.getCursor());
 			}
 		});

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,7 @@ export default class ICSPlugin extends Plugin {
 				if (e.location) {
 					event['location'] = e.location;
 				}
-
+                event['format'] = calendarSetting.format;
 				events.push(event);
 			});
 
@@ -86,11 +86,14 @@ export default class ICSPlugin extends Plugin {
 			editorCallback: async (editor: Editor, view: MarkdownView) => {
 				const fileDate = getDateFromFile(view.file, "day").format("YYYY-MM-DD");
 				var events: any[] = await this.getEvents(fileDate);
-				var mdArray: string[] = [];
-
-				events.forEach((e) => {
-					mdArray.push((`- [ ] ${e.time} ${e.icsName} ${e.summary} ${(e.location ? e.location : '')}`).trim());
-				});
+				const mdArray = events.map(e => {
+                    return [
+                        `- [ ] ${e.time}`,
+                        e.format.icsName ? e.icsName : null,
+                        e.format.summary ? e.summary : null,
+                        e.format.description ? `\n\t${e.description}` : null,
+                    ].filter(Boolean).join(' ')
+				});			
 				editor.replaceRange(mdArray.sort().join("\n"), editor.getCursor());
 			}
 		});

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,7 +91,7 @@ export default class ICSPlugin extends Plugin {
                         `- [ ] ${e.time}`,
                         e.format.icsName ? e.icsName : null,
                         e.format.summary ? e.summary : null,
-                        e.format.description ? `\n\t${e.description}` : null,
+                        e.format.description ? `\n\t- ${e.description}` : null,
                     ].filter(Boolean).join(' ')
 				});			
 				editor.replaceRange(mdArray.sort().join("\n"), editor.getCursor());

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,9 +89,9 @@ export default class ICSPlugin extends Plugin {
 				const mdArray = events.map(e => {
                     return [
                         `- [ ] ${e.time}`,
-                        e.format.icsName ? e.icsName : null,
-                        e.format.summary ? e.summary : null,
-                        e.format.description ? `\n\t- ${e.description}` : null,
+                        e.format?.icsName ? e.icsName : null,
+                        e.format?.summary ? e.summary : null,
+                        e.format?.description ? `\n\t- ${e.description}` : null,
                     ].filter(Boolean).join(' ')
 				});			
 				editor.replaceRange(mdArray.sort().join("\n"), editor.getCursor());

--- a/src/settings/ICSSettings.ts
+++ b/src/settings/ICSSettings.ts
@@ -5,6 +5,11 @@ export interface ICSSettings {
 export interface Calendar {
     icsUrl: string;
     icsName: string;
+    format: {
+        icsName: boolean;
+        summary: boolean;
+        description: boolean;
+    }
 }
 
 export const DEFAULT_SETTINGS: ICSSettings = {

--- a/src/settings/ICSSettingsTab.ts
+++ b/src/settings/ICSSettingsTab.ts
@@ -137,7 +137,7 @@ class SettingsModal extends Modal {
 		if (setting) {
 			this.icsName = setting.icsName;
 			this.icsUrl = setting.icsUrl;
-            this.format = setting.format;
+			this.format = setting.format || this.format // if format is undefined, use default
 		}
 	}
 

--- a/src/settings/ICSSettingsTab.ts
+++ b/src/settings/ICSSettingsTab.ts
@@ -60,7 +60,8 @@ export default class ICSSettingsTab extends PluginSettingTab {
 							if (modal.saved) {
 								this.plugin.addCalendar({
 									icsName: modal.icsName,
-									icsUrl: modal.icsUrl
+									icsUrl: modal.icsUrl,
+									format: modal.format
 								});
 								this.display();
 							}
@@ -94,7 +95,8 @@ export default class ICSSettingsTab extends PluginSettingTab {
 									this.plugin.removeCalendar(calendar);
 									this.plugin.addCalendar({
 										icsName: modal.icsName,
-										icsUrl: modal.icsUrl
+										icsUrl: modal.icsUrl,
+										format: modal.format
 									});
 									this.display();
 								}
@@ -121,11 +123,21 @@ class SettingsModal extends Modal {
 
 	saved: boolean = false;
 	error: boolean = false;
+    format: {
+        icsName: boolean,
+        summary: boolean,
+        description: boolean
+    }={
+		icsName: true,
+        summary: true,
+        description: true
+	};
 	constructor(app: App, setting?: Calendar) {
 		super(app);
 		if (setting) {
 			this.icsName = setting.icsName;
 			this.icsUrl = setting.icsUrl;
+            this.format = setting.format;
 		}
 	}
 
@@ -160,6 +172,32 @@ class SettingsModal extends Modal {
 				});
 			});
 
+        const formatSetting = new Setting(settingDiv)
+            .setName("Output Format");
+
+        const icsNameSetting = new Setting(settingDiv)
+            .setName('icsName')
+            .setDesc('Include the icsName field in the output')
+            .addToggle(toggle => toggle
+                .setValue(this.format.icsName || false)
+                .onChange(value => this.format.icsName = value));
+
+        const summaryName = new Setting(settingDiv)
+            .setName('summary')
+            .setDesc('Include the summary field in the output')
+            .addToggle(toggle => toggle
+                .setValue(this.format.summary || false)
+                .onChange(value => {
+                    this.format.summary = value;
+                    console.log("this.format.summary : ", this.format.summary)
+                }));
+
+        const dscSetting = new Setting(settingDiv)
+            .setName('description')
+            .setDesc('Include the description field in the output')
+            .addToggle(toggle => toggle
+                .setValue(this.format.description || false)
+                .onChange(value => this.format.description = value));
 		let footerEl = contentEl.createDiv();
 		let footerButtons = new Setting(footerEl);
 		footerButtons.addButton((b) => {


### PR DESCRIPTION
## Implement customizable output format for events

This Pull Request introduces a feature that allows users to customize the output format of their events. The key changes include:

1. **Adding Output Format Settings**: New settings have been added to the configuration modal. These settings allow users to decide whether to include the 'icsName', 'summary', and 'description' fields in the output. Each setting is represented as a toggle in the modal.

   ![Settings Modal](https://github.com/muness/obsidian-ics/assets/37897508/6b218bce-66f8-44b9-b012-85415f33a791)

2. **Saving Output Format Settings**: The chosen output format settings are saved along with other settings for future sessions.

3. **Applying Output Format Settings**: The saved output format settings are applied when generating the output for each event. Depending on the settings, 'icsName', 'summary', and 'description' fields are conditionally included in the output.

   ![In-use Example](https://github.com/muness/obsidian-ics/assets/37897508/24303a54-a2b6-4b85-8ecd-d43d343142e9)

These changes allow users to have a more personalized and relevant output, improving the overall user experience.