### PR TITLE
feat: Add support for development builds

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -10,6 +10,7 @@ if you want to view the source, please visit the github repository of this plugi
 `;
 
 const prod = (process.argv[2] === "production");
+const devBuild = (process.argv[2] === "dev-build");
 
 const context = await esbuild.context({
 	banner: {
@@ -37,11 +38,11 @@ const context = await esbuild.context({
 	logLevel: "info",
 	sourcemap: prod ? false : "inline",
 	minify: prod ? true : false,
-	treeShaking: true,
-	outfile: "dist/main.js",
+	treeShaking: prod ? true : false,
+	outfile: prod ? "dist/main.js" : "dist/main-debug.js",
 });
 
-if (prod) {
+if (prod || devBuild) {
 	await context.rebuild();
 	process.exit(0);
 } else {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "dev-build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs dev-build",
     "version": "node version-bump.mjs && git add manifest.json versions.json"
   },
   "keywords": [],


### PR DESCRIPTION
This commit adds support for development builds by introducing a new script `dev-build` in the `package.json` file. The build process in the `esbuild.config.mjs` file has been modified to include an option to generate a separate debug output file for development builds. The `context.rebuild()` function is now called for both production and development builds.