### PR TITLE
Correct recurring event timezone without using UTC offsets

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -35,7 +35,7 @@ const context = await esbuild.context({
 		...builtins],
 	format: "cjs",
 	target: "es2018",
-	logLevel: "info",
+	logLevel: prod ? "debug" : "info",
 	sourcemap: prod ? false : "inline",
 	minify: prod ? true : false,
 	treeShaking: prod ? true : false,


### PR DESCRIPTION
- correct recurring event timezone without using UTC offsets as relying on UTC offsets, offsets will change when DST happens.
- also add debug logging for recurring event matches + cloning + tz correction.

Fixes #79 